### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository implements a fully automated news publication built on Google’
 1. **Configuration first** – Update the JSON files in [`config/`](config/) to control feed sources, prompt wording, keyword rotation, and preferred OpenAI models.
 2. **Scheduled generation** – The workflow defined in [`.github/workflows/auto-blog.yml`](.github/workflows/auto-blog.yml) runs daily (cron `0 13 * * *`) or on demand. It installs dependencies, runs `npm run generate`, commits any new posts, builds the Eleventy site, and deploys it to GitHub Pages.
 3. **Content pipeline** – [`scripts/generate-posts.mjs`](scripts/generate-posts.mjs) fetches recent RSS items, assigns keywords round-robin, calls OpenAI with the configured prompt, and saves validated Markdown posts under `src/posts/YYYY/MM/slug/index.md` alongside YAML front matter that includes sources and metadata.
-4. **Static publishing** – `npm run build` produces an optimized site in the `dist/` directory using the Eleventy High Performance Blog stack. Lighthouse-friendly defaults remain intact.
+4. **Static publishing** – `npm run build` produces an optimized site in the `_site/` directory using the Eleventy High Performance Blog stack. Lighthouse-friendly defaults remain intact.
 
 ## Repository layout
 
@@ -74,7 +74,7 @@ Static pages such as [About](src/about/index.md) and [Sources Policy](src/source
 
 ## Deployment
 
-GitHub Pages is deployed through the `auto-blog` workflow. Successful runs upload the `dist/` directory using the official `actions/deploy-pages` action. Ensure GitHub Pages is configured to use **GitHub Actions** as the deployment source under **Settings → Pages**.
+GitHub Pages is deployed through the `deploy` workflow. Successful runs upload the `_site/` directory using the official `actions/deploy-pages` action. Ensure GitHub Pages is configured to use **GitHub Actions** as the deployment source under **Settings → Pages**.
 
 ## Credits
 

--- a/_11ty/output-dir.js
+++ b/_11ty/output-dir.js
@@ -1,1 +1,1 @@
-module.exports = "dist";
+module.exports = "_site";

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "debug": "DEBUG=* eleventy && npm run test",
     "test": "mocha test/test*.js",
     "test-watch": "mocha test/test*.js --watch --watch-files=test/*",
-    "clean": "rm -Rf ./dist/posts/*",
+    "clean": "rm -Rf ./_site/posts/*",
     "generate": "node scripts/generate-posts.mjs",
     "generate:dry": "node scripts/generate-posts.mjs --dry-run --verbose"
   },

--- a/test/test-generic-post.js
+++ b/test/test-generic-post.js
@@ -15,7 +15,7 @@ const GA_ID = require("../_data/googleanalytics.js")();
 
 describe("check build output for a generic post", () => {
   describe("sample post", () => {
-    const POST_FILENAME = "dist/posts/firstpost/index.html";
+    const POST_FILENAME = "_site/posts/firstpost/index.html";
     const URL = metadata.url;
     const POST_URL = URL + "/posts/firstpost/";
 

--- a/test/test-homepage.js
+++ b/test/test-homepage.js
@@ -6,7 +6,7 @@ const existsSync = require("fs").existsSync;
 
 describe("check build output for homepage", () => {
   describe("homepage", () => {
-    const FILENAME = "dist/index.html";
+    const FILENAME = "_site/index.html";
 
     if (!existsSync(FILENAME)) {
       it("WARNING skipping tests because FILENAME does not exist", () => {});

--- a/test/test-post-drafted.js
+++ b/test/test-post-drafted.js
@@ -18,7 +18,7 @@ describe("Draft posts", function () {
     return;
   }
   describe("draft post", () => {
-    const DRAFT_POST = "dist/posts/fifthpost/index.html";
+    const DRAFT_POST = "_site/posts/fifthpost/index.html";
 
     it("w. draft: true should NOT be rendered", () => {
       var draftfileexists = false;
@@ -34,7 +34,7 @@ describe("Draft posts", function () {
     });
   });
   describe("draft post from future", () => {
-    const DRAFT_POST_FUTURE = "dist/posts/sixthpostdraft/index.html";
+    const DRAFT_POST_FUTURE = "_site/posts/sixthpostdraft/index.html";
 
     it("should NOT be rendered", () => {
       var draftpostfutureexists = false;


### PR DESCRIPTION
## Summary
- disable Jekyll on GitHub Pages with an empty `.nojekyll` marker
- update the Eleventy output directory to `_site` and adjust scripts, tests, and docs accordingly
- add a Pages deployment workflow that builds with Node 20 and publishes the `_site` artifact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d49fa88a3483328837f5fbb62b526a