### PR TITLE
fix: enable real posts and homepage loop

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -149,6 +149,14 @@ module.exports = function (eleventyConfig) {
     );
   });
 
+  eleventyConfig.addFilter("date", (dateObj, format = "dd LLL yyyy") => {
+    if (!dateObj) {
+      return "";
+    }
+    const jsDate = dateObj instanceof Date ? dateObj : new Date(dateObj);
+    return DateTime.fromJSDate(jsDate, { zone: "utc" }).toFormat(format);
+  });
+
   // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-date-string
   eleventyConfig.addFilter("htmlDateString", (dateObj) => {
     return DateTime.fromJSDate(dateObj, { zone: "utc" }).toFormat("yyyy-LL-dd");
@@ -171,6 +179,9 @@ module.exports = function (eleventyConfig) {
     return array.slice(0, n);
   });
 
+  eleventyConfig.addCollection("post", function (collectionApi) {
+    return collectionApi.getFilteredByGlob("src/posts/**/*.md");
+  });
   eleventyConfig.addCollection("posts", function (collectionApi) {
     return collectionApi.getFilteredByTag("posts");
   });

--- a/index.njk
+++ b/index.njk
@@ -13,6 +13,11 @@ date: Last Modified
 
 <div id="posts">
   <h2>Posts</h2>
-  {% set postslist = collections.posts %}
-  {% include "postslist.njk" %}
+  <ul>
+    {% for post in collections.post %}
+      <li>
+        <a href="{{ post.url }}">{{ post.data.title }}</a> – {{ post.date | date("dd MMM yyyy") }}
+      </li>
+    {% endfor %}
+  </ul>
 </div>

--- a/src/posts/hello-world.md
+++ b/src/posts/hello-world.md
@@ -1,0 +1,10 @@
+---
+title: "Hello World"
+description: "This is the first real post in the Eleventy blog."
+date: 2025-09-24
+tags: [intro, test]
+---
+
+# Welcome to the Blog
+
+This inaugural post demonstrates that Eleventy is now configured to render real content. Feel free to customize it further as you continue building out the site.


### PR DESCRIPTION
## Summary
- add a reusable `date` filter and a `post` collection that sources Markdown files from `src/posts`
- replace the homepage's hardcoded demo posts with a loop over the real Eleventy collection
- add a starter "Hello World" post to verify the collection renders correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4b5f6461c8332bf6dac840a1a4e1d