### PR TITLE
Fix Eleventy blog deployment for GitHub Pages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -225,6 +225,8 @@ module.exports = function (eleventyConfig) {
   return {
     templateFormats: ["md", "njk", "html", "liquid"],
 
+    pathPrefix: "/blog/",
+
     // If your site lives in a different subdirectory, change this.
     // Leading or trailing slashes are all normalized away, so don’t worry about those.
 

--- a/.github/workflows/auto-blog.yml
+++ b/.github/workflows/auto-blog.yml
@@ -57,12 +57,12 @@ jobs:
         run: npm run build
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: _site
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "debug": "DEBUG=* eleventy && npm run test",
     "test": "mocha test/test*.js",
     "test-watch": "mocha test/test*.js --watch --watch-files=test/*",
-    "clean": "rm -Rf ./_site/posts/*",
+    "clean": "rm -Rf ./_site/posts/* ./_site/blog/posts/*",
     "generate": "node scripts/generate-posts.mjs",
     "generate:dry": "node scripts/generate-posts.mjs --dry-run --verbose"
   },

--- a/src/posts/posts.11tydata.js
+++ b/src/posts/posts.11tydata.js
@@ -28,7 +28,7 @@ module.exports = () => {
         const relative = stem
           .replace(/^posts\//, "")
           .replace(/\/index$/, "");
-        return `/posts/${relative}/index.html`;
+        return `/blog/posts/${relative}/index.html`;
       },
     },
     tags: ["posts"],


### PR DESCRIPTION
## Summary
- set Eleventy's pathPrefix to `/blog/` and keep the build output in `_site`
- update post permalinks to emit pages under `/blog/posts/{slug}/`
- fix automation workflow and clean script to deploy the generated `_site` content reliably

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d555751f5883328aa4c442c99d0704