### PR TITLE
Sync workflow cron with config

### DIFF
--- a/.github/workflows/auto-blog.yml
+++ b/.github/workflows/auto-blog.yml
@@ -2,7 +2,7 @@ name: Automated AI-SEO Blog
 
 on:
   schedule:
-    - cron: "0 13 * * *"
+    - cron: "0 16,18,20,22 * * *"
   workflow_dispatch:
 
 permissions:
@@ -32,6 +32,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Sync workflow cron from config
+        run: node scripts/update-workflow.mjs
 
       - name: Generate posts
         env:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository implements a fully automated news publication built on Google’
 ## How it works
 
 1. **Configuration first** – Update the JSON files in [`config/`](config/) to control feed sources, prompt wording, keyword rotation, and preferred OpenAI models.
-2. **Scheduled generation** – The workflow defined in [`.github/workflows/auto-blog.yml`](.github/workflows/auto-blog.yml) runs daily (cron `0 13 * * *`) or on demand. It installs dependencies, runs `npm run generate`, commits any new posts, builds the Eleventy site, and deploys it to GitHub Pages.
+2. **Scheduled generation** – The workflow defined in [`.github/workflows/auto-blog.yml`](.github/workflows/auto-blog.yml) runs on the cron expression defined by `scheduleCron` in [`config/news.config.json`](config/news.config.json) (default `0 16,18,20,22 * * *`) or on demand. It installs dependencies, runs `npm run generate`, commits any new posts, builds the Eleventy site, and deploys it to GitHub Pages.
 3. **Content pipeline** – [`scripts/generate-posts.mjs`](scripts/generate-posts.mjs) fetches recent RSS items, assigns keywords round-robin, calls OpenAI with the configured prompt, and saves validated Markdown posts under `src/posts/YYYY/MM/slug/index.md` alongside YAML front matter that includes sources and metadata.
 4. **Static publishing** – `npm run build` produces an optimized site in the `_site/` directory using the Eleventy High Performance Blog stack. Lighthouse-friendly defaults remain intact.
 
@@ -54,6 +54,15 @@ npm start              # Starts Eleventy’s dev server at http://localhost:8080
 ```
 
 Generated posts live in `src/posts/<year>/<month>/<slug>/index.md`. Eleventy collections pick them up automatically thanks to [`src/posts/posts.11tydata.js`](src/posts/posts.11tydata.js), and the sitemap/RSS feeds are rebuilt on every deploy.
+
+## Usage
+
+To change the publishing cadence, edit the `scheduleCron` value in [`config/news.config.json`](config/news.config.json).
+
+- `"0 16,18,20,22 * * *"` → run at 16:00, 18:00, 20:00, and 22:00 UTC every day.
+- `"0 9 * * *"` → run once daily at 09:00 UTC.
+
+GitHub Actions automatically syncs its workflow schedule to match this configuration on the next run.
 
 ## Adding or editing content
 

--- a/scripts/update-workflow.mjs
+++ b/scripts/update-workflow.mjs
@@ -1,0 +1,115 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const configPath = path.join(repoRoot, 'config', 'news.config.json');
+const workflowPath = path.join(repoRoot, '.github', 'workflows', 'auto-blog.yml');
+
+function warnAndExit(message) {
+  console.warn(`[update-workflow] ${message}`);
+  process.exitCode = 0;
+}
+
+async function readScheduleCron() {
+  let rawConfig;
+  try {
+    rawConfig = await readFile(configPath, 'utf8');
+  } catch (error) {
+    warnAndExit(`Unable to read configuration at ${configPath}: ${error.message}`);
+    return null;
+  }
+
+  let config;
+  try {
+    config = JSON.parse(rawConfig);
+  } catch (error) {
+    warnAndExit(`Invalid JSON in ${configPath}: ${error.message}`);
+    return null;
+  }
+
+  const scheduleCron = config?.scheduleCron;
+  if (typeof scheduleCron !== 'string' || !scheduleCron.trim()) {
+    warnAndExit('Missing or empty "scheduleCron" value in config/news.config.json.');
+    return null;
+  }
+
+  const parts = scheduleCron.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    warnAndExit(
+      `Invalid cron expression "${scheduleCron}". Expected 5 fields but received ${parts.length}.`
+    );
+    return null;
+  }
+
+  return scheduleCron.trim();
+}
+
+async function updateWorkflowCron(cronExpression) {
+  let workflowContent;
+  try {
+    workflowContent = await readFile(workflowPath, 'utf8');
+  } catch (error) {
+    warnAndExit(`Unable to read workflow file at ${workflowPath}: ${error.message}`);
+    return false;
+  }
+
+  const cronRegex = /(on:\s*\n\s*schedule:\s*\n\s*-\s*cron:\s*")(.*?)("\s*)/;
+  const match = workflowContent.match(cronRegex);
+
+  if (!match) {
+    warnAndExit('Could not locate a cron schedule definition in the workflow file.');
+    return false;
+  }
+
+  if (match[2] === cronExpression) {
+    console.log('[update-workflow] Workflow cron already matches configuration.');
+    return false;
+  }
+
+  const updatedContent = workflowContent.replace(cronRegex, `$1${cronExpression}$3`);
+  await writeFile(workflowPath, updatedContent);
+  console.log(`[update-workflow] Updated workflow cron to "${cronExpression}".`);
+  return true;
+}
+
+async function commitChangesIfNeeded() {
+  try {
+    await execFileAsync('git', ['config', 'user.name', 'github-actions[bot]']);
+    await execFileAsync('git', [
+      'config',
+      'user.email',
+      '41898282+github-actions[bot]@users.noreply.github.com'
+    ]);
+    await execFileAsync('git', ['add', '.github/workflows/auto-blog.yml']);
+    await execFileAsync('git', ['commit', '-m', 'chore(auto): sync workflow cron from config']);
+    console.log('[update-workflow] Committed updated workflow schedule.');
+  } catch (error) {
+    if (error.code === 1) {
+      console.log('[update-workflow] No commit created (likely no changes to add).');
+    } else {
+      warnAndExit(`Failed to create commit: ${error.message}`);
+    }
+  }
+}
+
+async function main() {
+  const cronExpression = await readScheduleCron();
+  if (!cronExpression) {
+    return;
+  }
+
+  const updated = await updateWorkflowCron(cronExpression);
+  if (!updated) {
+    return;
+  }
+
+  await commitChangesIfNeeded();
+}
+
+await main();


### PR DESCRIPTION
## Summary
- add a Node.js helper script that reads `scheduleCron` from `config/news.config.json`, updates the workflow schedule, and commits changes automatically
- invoke the helper in the publishing workflow so the cron expression stays in sync before generating posts
- document how to adjust the schedule via `scheduleCron` in the README with common cron examples

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5e9e053848332ba1dc611e048a19b