### PR TITLE
Stop auto-blog workflow from deploying to Pages

### DIFF
--- a/.github/workflows/auto-blog.yml
+++ b/.github/workflows/auto-blog.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 concurrency:
   group: ai-seo-blog
@@ -59,14 +57,3 @@ jobs:
       - name: Build site
         run: npm run build
 
-      - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: _site
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- remove unnecessary GitHub Pages permissions from the auto-blog workflow
- stop the workflow after the build step by deleting the Pages deployment actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d69c987bac83329ad5a9ce2b8986c8