### PR TITLE
Simplify build workflow

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -18,11 +16,6 @@ concurrency:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
-    # IMPORTANT: environment must be on the SAME job that calls deploy-pages
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,15 +30,3 @@ jobs:
 
       - name: Build site
         run: npm run build
-
-      - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: _site
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- remove GitHub Pages deployment permissions from the workflow
- trim the build-and-publish job to only checkout, install dependencies, and run the build

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d69cfa72f883328943975238551e24