### PR TITLE
Add push step to auto blog workflow

### DIFF
--- a/.github/workflows/auto-blog.yml
+++ b/.github/workflows/auto-blog.yml
@@ -40,6 +40,7 @@ jobs:
         run: npm run generate
 
       - name: Commit changes
+        id: commit
         run: |
           if [[ -n "$(git status --porcelain)" ]]; then
             git config user.name "github-actions[bot]"
@@ -52,7 +53,19 @@ jobs:
               SLUG=$(date -u +"%H%M%S")
             fi
             git commit -m "chore(auto): add post $(date -u +"%Y-%m-%d")-$SLUG"
+            echo "changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changes=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Push changes
+        if: steps.commit.outputs.changes == 'true'
+        run: |
+          REF="${{ github.ref_name }}"
+          if [[ -z "$REF" ]]; then
+            REF=main
+          fi
+          git push origin HEAD:"$REF"
 
       - name: Build site
         run: npm run build


### PR DESCRIPTION
## Summary
- set commit step to report whether changes were committed
- push updates when commits are created by the auto blog workflow

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6cec6987c8332becbed336f15ec81