### PR TITLE
Make Eleventy path prefix configurable

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -59,8 +59,11 @@ const localImages = require("./third_party/eleventy-plugin-local-images/.elevent
 const CleanCSS = require("clean-css");
 const GA_ID = require("./_data/metadata.json").googleAnalyticsId;
 const OUTPUT_DIR = require("./_11ty/output-dir");
+const DEFAULT_PATH_PREFIX = "/";
 
 module.exports = function (eleventyConfig) {
+  const pathPrefix = process.env.ELEVENTY_PATH_PREFIX || DEFAULT_PATH_PREFIX;
+
   eleventyConfig.addPlugin(pluginRss);
   eleventyConfig.addPlugin(pluginSyntaxHighlight);
   eleventyConfig.addPlugin(pluginNavigation);
@@ -225,7 +228,7 @@ module.exports = function (eleventyConfig) {
   return {
     templateFormats: ["md", "njk", "html", "liquid"],
 
-    pathPrefix: "/blog/",
+    pathPrefix,
 
     // If your site lives in a different subdirectory, change this.
     // Leading or trailing slashes are all normalized away, so don’t worry about those.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Static pages such as [About](src/about/index.md) and [Sources Policy](src/source
 
 GitHub Pages is deployed through the `deploy` workflow. Successful runs upload the `_site/` directory using the official `actions/deploy-pages` action. Ensure GitHub Pages is configured to use **GitHub Actions** as the deployment source under **Settings → Pages**.
 
+When hosting the site in a subdirectory (for example, `https://example.com/blog/`), set the `ELEVENTY_PATH_PREFIX` environment variable to that path (including the leading and trailing slashes) before running `npm run build` or the GitHub Pages workflow. The Eleventy configuration reads this value and applies it to generated URLs; it defaults to `/` for root deployments.
+
 ## Credits
 
 This project builds on Google’s Eleventy High Performance Blog starter and keeps all of its performance optimizations, including critical CSS inlining, responsive image pipelines, AMP optimization, and strong CSP defaults.


### PR DESCRIPTION
## Summary
- allow overriding the Eleventy path prefix through an ELEVENTY_PATH_PREFIX environment variable, defaulting to "/"
- document how to set ELEVENTY_PATH_PREFIX for subdirectory deployments in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6dcb81da08332bc58f2db0b987700