### PR TITLE
Limit auto-blog workflow staging to generated files

### DIFF
--- a/.github/workflows/auto-blog.yml
+++ b/.github/workflows/auto-blog.yml
@@ -42,21 +42,31 @@ jobs:
       - name: Commit changes
         id: commit
         run: |
-          if [[ -n "$(git status --porcelain)" ]]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add -A
-            FIRST_POST=$(git diff --cached --name-only | grep '^src/posts/' | head -n 1)
-            if [[ -n "$FIRST_POST" ]]; then
-              SLUG=$(basename "$(dirname "$FIRST_POST")")
-            else
-              SLUG=$(date -u +"%H%M%S")
-            fi
-            git commit -m "chore(auto): add post $(date -u +"%Y-%m-%d")-$SLUG"
-            echo "changes=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changes=false" >> "$GITHUB_OUTPUT"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if [[ -d src/posts ]]; then
+            git add src/posts/
           fi
+
+          if [[ -f .cache/state.json ]]; then
+            git add .cache/state.json
+          fi
+
+          if git diff --cached --quiet; then
+            echo "changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          FIRST_POST=$(git diff --cached --name-only | grep '^src/posts/' | head -n 1)
+          if [[ -n "$FIRST_POST" ]]; then
+            SLUG=$(basename "$(dirname "$FIRST_POST")")
+          else
+            SLUG=$(date -u +"%H%M%S")
+          fi
+
+          git commit -m "chore(auto): add post $(date -u +"%Y-%m-%d")-$SLUG"
+          echo "changes=true" >> "$GITHUB_OUTPUT"
 
       - name: Push changes
         if: steps.commit.outputs.changes == 'true'


### PR DESCRIPTION
## Summary
- update the auto-blog workflow to stage only generated posts and cache state before committing
- add a cached-diff guard so runs skip committing when no generated files are staged and retain slug detection based on staged changes

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d70ce0ff1c8332aa6383793fd2c479