### PR TITLE
chore: skip workflow auto-commit in CI

### DIFF
--- a/scripts/update-workflow.mjs
+++ b/scripts/update-workflow.mjs
@@ -79,6 +79,11 @@ async function updateWorkflowCron(cronExpression) {
 }
 
 async function commitChangesIfNeeded() {
+  const allowCommit = process.env.UPDATE_WORKFLOW_ALLOW_COMMIT === 'true';
+  if (process.env.GITHUB_ACTIONS === 'true' && !allowCommit) {
+    console.log('[update-workflow] Skipping commit while running in GitHub Actions.');
+    return;
+  }
   try {
     await execFileAsync('git', ['config', 'user.name', 'github-actions[bot]']);
     await execFileAsync('git', [


### PR DESCRIPTION
## Summary
- skip committing workflow updates when the script runs inside GitHub Actions unless explicitly allowed via UPDATE_WORKFLOW_ALLOW_COMMIT

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d718c081948332b6398716b31d0820