### PR TITLE
Ensure Eleventy builds run with blog path prefix

### DIFF
--- a/.github/workflows/auto-blog.yml
+++ b/.github/workflows/auto-blog.yml
@@ -79,4 +79,6 @@ jobs:
 
       - name: Build site
         run: npm run build
+        env:
+          ELEVENTY_PATH_PREFIX: /blog/
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Build site
         run: npm run build
+        env:
+          ELEVENTY_PATH_PREFIX: /blog/
 
       - name: Configure Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary
- set ELEVENTY_PATH_PREFIX in the deploy workflow build step so GitHub Pages publishes under /blog/
- inject the same path prefix into the auto-blog workflow build to keep generated content paths consistent

## Testing
- ELEVENTY_PATH_PREFIX=/blog/ npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7204fc2f48332a608f379d3c4b64c