### PR TITLE
Fix post permalinks to respect Eleventy path prefix

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -225,7 +225,7 @@ module.exports = function (eleventyConfig) {
   return {
     templateFormats: ["md", "njk", "html", "liquid"],
 
-    pathPrefix: "/",
+    pathPrefix: "/blog",
 
     markdownTemplateEngine: "liquid",
     htmlTemplateEngine: "njk",

--- a/src/posts/posts.11tydata.js
+++ b/src/posts/posts.11tydata.js
@@ -28,7 +28,7 @@ module.exports = () => {
         const relative = stem
           .replace(/^posts\//, "")
           .replace(/\/index$/, "");
-        return `/blog/posts/${relative}/index.html`;
+        return `/posts/${relative}/index.html`;
       },
     },
     tags: ["posts"],


### PR DESCRIPTION
## Summary
- drop the hard-coded /blog prefix from post permalinks so Eleventy can manage the path prefix
- configure Eleventy with a /blog pathPrefix so generated URLs include the site path on derived assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d73502347483328da31ea0f84b712e