### PR TITLE
Wrap Eleventy homepage links with url filter

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -16,7 +16,7 @@ date: Last Modified
   <ul>
     {% for post in collections.post %}
       <li>
-        <a href="{{ post.url }}">{{ post.data.title }}</a> – {{ post.date | date("dd MMM yyyy") }}
+        <a href="{{ post.url | url }}">{{ post.data.title }}</a> – {{ post.date | date("dd MMM yyyy") }}
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
## Summary
- wrap the homepage post links with Eleventy's `url` filter to ensure generated anchors include the correct prefix

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d745f78a5083329e4b2fa9cfd6798f