### PR TITLE
Use url filter for About footer link

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -95,7 +95,7 @@
     </main>
 
     <footer>
-      <a href="/about/">{{ metadata.author.name }}</a>
+      <a href="{{ '/about/' | url }}">{{ metadata.author.name }}</a>
     </footer>
 
     <!-- Current page: {{ page.url | url }} -->


### PR DESCRIPTION
## Summary
- use the Eleventy `url` filter for the footer's About link so it respects the site path prefix

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d74707f24883329be32935642801af