### PR TITLE
Fix canonical and share URLs to respect path prefix

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -36,7 +36,7 @@
       <meta property="og:image" content="{{ image | absoluteUrl(metadata.url) }}">
     {% endif %}
 
-    <link rel="canonical" href="{{ metadata.url }}{{ canonicalUrl or page.url }}">
+    <link rel="canonical" href="{{ (canonicalUrl or page.url) | url | absoluteUrl(metadata.url) }}">
     <!-- This is a blog and so it SHOULD be safe and it is nice for the web
          to send referrers cross-origin.
          However, if you use sensitive data in URLs, consider changing this to

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -13,7 +13,7 @@ templateClass: tmpl-post
    </aside>
 {% endblock %}
 
-{% set shareUrl = metadata.url + page.url %}
+{% set shareUrl = page.url | url | absoluteUrl(metadata.url) %}
 
 {% block article %}
 {{ content | safe }}
@@ -44,11 +44,11 @@ templateClass: tmpl-post
     "name": "{{ metadata.publisher.name }}",
     "logo": {
       "@type": "ImageObject",
-      "url": "{{ '/img/favicon/favicon-192x192.png' | addHash }}"
+      "url": "{{ '/img/favicon/favicon-192x192.png' | addHash | url | absoluteUrl(metadata.url) }}"
     }
   },
-  "url": "{{ metadata.url }}{{ canonicalUrl or page.url }}",
-  "mainEntityOfPage": "{{ metadata.url }}{{ canonicalUrl or page.url }}",
+  "url": "{{ (canonicalUrl or page.url) | url | absoluteUrl(metadata.url) }}",
+  "mainEntityOfPage": "{{ (canonicalUrl or page.url) | url | absoluteUrl(metadata.url) }}",
   "datePublished": "{{ page.date | htmlDateString }}",
   "dateModified": "{{ page.inputPath | lastModifiedDate  | htmlDateString }}",
   "description": "{{ content | striptags | truncate(140) }}"


### PR DESCRIPTION
## Summary
- apply Eleventy's `url` filter before `absoluteUrl` so canonical, share, and structured data URLs honor the configured path prefix
- reuse the filtered share URL for post share links and structured data fields
- ensure the JSON-LD publisher logo uses a hashed asset URL that respects the prefix

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d75639d9648332b19888000ecc16d6