### PR TITLE
Fix share widget asset URLs for path prefix builds

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -58,6 +58,15 @@
     <script csp-hash>if (/Mac OS X/.test(navigator.userAgent))document.documentElement.classList.add('apple')
     </script>
     <!-- css is inserted by optimize-html custom plugin -->
+    <style>
+      share-widget div {
+        background-image: url("{{ '/img/share.svg' | url }}");
+      }
+
+      .apple share-widget div {
+        background-image: url("{{ '/img/share-apple.svg' | url }}");
+      }
+    </style>
   </head>
   <body>
     <header>

--- a/css/main.css
+++ b/css/main.css
@@ -52,13 +52,8 @@ share-widget {
 share-widget div {
   width: 30px;
   height: 30px;
-  background-image: url("/img/share.svg");
   background-repeat: no-repeat;
   background-position: center;
-}
-
-.apple share-widget div {
-  background-image: url("/img/share-apple.svg");
 }
 
 share-widget button {


### PR DESCRIPTION
## Summary
- move share widget background images into the base layout with Eleventy URL filters so they honor the configured path prefix
- remove the hard-coded /img background images from the main stylesheet so only the prefixed versions remain

## Testing
- ELEVENTY_PATH_PREFIX=/blog npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d75694928c8332b4bf2f71419c3dbc