### PR TITLE
Stop building Eleventy in auto-blog workflow

### DIFF
--- a/.github/workflows/auto-blog.yml
+++ b/.github/workflows/auto-blog.yml
@@ -75,10 +75,3 @@ jobs:
           fi
           git push origin HEAD:"$REF"
 
-      - name: Clean _site
-        run: rm -rf _site
-
-      - name: Build site
-        run: npm run build
-        env:
-          ELEVENTY_PATH_PREFIX: /blog/


### PR DESCRIPTION
## Summary
- remove the Eleventy clean and build steps from auto-blog so it only pushes generated posts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7f40c187c833283430b1afa1ab38a