### PR TITLE
Ensure asset URLs honor the Eleventy path prefix

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -33,7 +33,7 @@
     <meta name="twitter:site" content="@{{ metadata.author.twitterHandle }}">
     <meta name="twitter:creator" content="@{{ metadata.author.twitterHandle }}">
     {% if image %}
-      <meta property="og:image" content="{{ image | absoluteUrl(metadata.url) }}">
+      <meta property="og:image" content="{{ image | url | absoluteUrl(metadata.url) }}">
     {% endif %}
 
     <link rel="canonical" href="{{ (canonicalUrl or page.url) | url | absoluteUrl(metadata.url) }}">

--- a/index.njk
+++ b/index.njk
@@ -2,7 +2,8 @@
 title: uPatch Luggage Scale
 layout: layouts/home.njk
 description: Expert travel guides, baggage allowance hacks, and tips for using the battery-free uPatch luggage scale. Make your trips lighter and stress-free.
-image: /img/share.svg
+eleventyComputed:
+  image: "{{ '/img/share.svg' | url }}"
 date: Last Modified
 ---
 

--- a/src/posts/secondpost.md
+++ b/src/posts/secondpost.md
@@ -21,7 +21,7 @@ Capitalize on low hanging fruit to identify a ballpark value added activity to b
 
 # Test SVG
 
-![Test Share SVG](/img/share.svg)
+![Test Share SVG]({{ '/img/share.svg' | url }})
 
 # Test Relative Local Image
 


### PR DESCRIPTION
## Summary
- pipe page images through Eleventy’s `url` filter before `absoluteUrl` so social metadata respects the configured path prefix
- compute the homepage share image using the `url` filter and update markdown image links to use templated URLs for `/img` assets

## Testing
- ELEVENTY_PATH_PREFIX=/blog npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7f4453d1c83329a5be27f7ac7b21b