### PR TITLE
Add homepage hero image and ensure OG metadata works with pathPrefix

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -33,7 +33,7 @@
     <meta name="twitter:site" content="@{{ metadata.author.twitterHandle }}">
     <meta name="twitter:creator" content="@{{ metadata.author.twitterHandle }}">
     {% if image %}
-      <meta property="og:image" content="{{ image | absoluteUrl(metadata.url) }}">
+      <meta property="og:image" content="{{ image | url | absoluteUrl(metadata.url) }}">
     {% endif %}
 
     <link rel="canonical" href="{{ metadata.url }}{{ canonicalUrl or page.url }}">

--- a/img/hero-luggage-scale.svg
+++ b/img/hero-luggage-scale.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">uPatch luggage scale hero graphic</title>
+  <desc id="desc">Illustration of a traveler checking baggage weight with a uPatch luggage scale.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0e7490" />
+      <stop offset="100%" stop-color="#38bdf8" />
+    </linearGradient>
+    <linearGradient id="bag" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#fcd34d" />
+      <stop offset="100%" stop-color="#f59e0b" />
+    </linearGradient>
+    <linearGradient id="scale" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ecfeff" />
+      <stop offset="100%" stop-color="#bae6fd" />
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-opacity="0.25" />
+    </filter>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" rx="32" />
+  <g transform="translate(140 120)" fill="none">
+    <rect x="0" y="220" width="920" height="220" fill="rgba(255,255,255,0.12)" rx="48" />
+    <rect x="620" y="40" width="220" height="360" fill="rgba(15,118,110,0.3)" rx="110" />
+  </g>
+  <g transform="translate(280 130)">
+    <rect x="0" y="70" width="340" height="360" rx="72" fill="url(#bag)" filter="url(#shadow)" />
+    <rect x="70" y="0" width="200" height="110" rx="40" fill="#78350f" />
+    <rect x="120" y="24" width="100" height="40" rx="20" fill="#fed7aa" />
+    <rect x="40" y="120" width="260" height="220" rx="48" fill="#fef08a" opacity="0.6" />
+    <g transform="translate(100 210)">
+      <rect x="0" y="0" width="140" height="140" rx="28" fill="#1d4ed8" />
+      <path d="M32 64h76" stroke="#bfdbfe" stroke-width="12" stroke-linecap="round" />
+      <path d="M48 96h44" stroke="#bfdbfe" stroke-width="12" stroke-linecap="round" />
+      <circle cx="70" cy="44" r="20" fill="#bfdbfe" />
+    </g>
+  </g>
+  <g transform="translate(620 150)">
+    <rect x="60" y="0" width="360" height="140" rx="70" fill="url(#scale)" filter="url(#shadow)" />
+    <rect x="200" y="-60" width="80" height="120" rx="40" fill="#0f766e" />
+    <rect x="0" y="180" width="520" height="220" rx="110" fill="#f8fafc" opacity="0.25" />
+    <g transform="translate(120 32)">
+      <rect x="0" y="0" width="200" height="76" rx="36" fill="#0f172a" />
+      <text x="100" y="48" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="42" fill="#e0f2fe" text-anchor="middle">2.1 kg</text>
+    </g>
+    <path d="M220 80v140" stroke="#0f172a" stroke-width="14" stroke-linecap="round" />
+    <g transform="translate(80 220)">
+      <path d="M60 0c-33 0-60 27-60 60s27 60 60 60h200c33 0 60-27 60-60s-27-60-60-60z" fill="#1f2937" opacity="0.18" />
+    </g>
+  </g>
+  <g transform="translate(160 470)">
+    <text x="0" y="0" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="52" font-weight="600" fill="#f8fafc">
+      Travel light with the uPatch luggage scale
+    </text>
+    <text x="0" y="64" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="30" fill="#e0f2fe">
+      Shake-to-charge tech and smart packing tips to keep your journeys stress-free.
+    </text>
+  </g>
+</svg>

--- a/index.njk
+++ b/index.njk
@@ -2,7 +2,7 @@
 title: uPatch Luggage Scale
 layout: layouts/home.njk
 description: Expert travel guides, baggage allowance hacks, and tips for using the battery-free uPatch luggage scale. Make your trips lighter and stress-free.
-image: /blog/static/logo.svg
+image: /img/hero-luggage-scale.svg
 date: Last Modified
 ---
 


### PR DESCRIPTION
## Summary
- add a bespoke uPatch luggage scale hero SVG asset for the homepage
- point the homepage front matter image to the new hero artwork
- update the base layout so og:image URLs respect Eleventy's pathPrefix handling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9835e4f00833290cbcf821ee675fe