### PR TITLE
Update Access-Control-Allow-Origin header configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -21,7 +21,7 @@
         },
         {
           "key": "Access-Control-Allow-Origin",
-          "value": "n/a"
+          "value": "*"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- set the default `Access-Control-Allow-Origin` header to `*` to ensure responses include a valid CORS value
- confirmed no other header blocks conflict with the global CORS configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d98641339c83328dc11c353efc0bb4