### PR TITLE
Fix hashed asset URLs to respect pathPrefix

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -59,6 +59,7 @@ const localImages = require("./third_party/eleventy-plugin-local-images/.elevent
 const CleanCSS = require("clean-css");
 const GA_ID = require("./_data/metadata.json").googleAnalyticsId;
 const OUTPUT_DIR = require("./_11ty/output-dir");
+const PATH_PREFIX = "/blog/";
 
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPlugin(pluginRss);
@@ -82,14 +83,21 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addNunjucksAsyncFilter(
     "addHash",
     function (absolutePath, callback) {
-      readFile(path.join(".", absolutePath), {
+      const normalizedPath = absolutePath.replace(/^\/+/, "");
+      readFile(path.join(".", normalizedPath), {
         encoding: "utf-8",
       })
         .then((content) => {
           return hasha.async(content);
         })
         .then((hash) => {
-          callback(null, `${absolutePath}?hash=${hash.substr(0, 10)}`);
+          const normalizedPrefix = PATH_PREFIX.endsWith("/")
+            ? PATH_PREFIX
+            : `${PATH_PREFIX}/`;
+          callback(
+            null,
+            `${normalizedPrefix}${normalizedPath}?hash=${hash.substr(0, 10)}`
+          );
         })
         .catch((error) => {
           callback(
@@ -225,7 +233,7 @@ module.exports = function (eleventyConfig) {
   return {
     templateFormats: ["md", "njk", "html", "liquid"],
 
-    pathPrefix: "/blog/",
+    pathPrefix: PATH_PREFIX,
 
     // If your site lives in a different subdirectory, change this.
     // Leading or trailing slashes are all normalized away, so don’t worry about those.

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -15,7 +15,7 @@
     {% if isdevelopment %}
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     {% else %}
-    <link rel="icon" href="{{ '/img/favicon/favicon-192x192.png' | addHash }}" type="image/png">
+    <link rel="icon" href="{{ 'img/favicon/favicon-192x192.png' | addHash }}" type="image/png">
     {% endif %}
     <meta name="theme-color" content="#f9c412">
     <meta name="robots" content="max-snippet:-1, max-image-preview: large, max-video-preview: -1">
@@ -48,11 +48,11 @@
 
     <link rel="preconnect" href="/" crossorigin>
     <link rel="preload" href="/fonts/Inter-3.19.var.woff2" as="font" type="font/woff2" crossorigin>
-    <script async defer src="{{ "/js/min.js" | addHash }}"
-      {% if webvitals %}data-cwv-src="{{ "/js/web-vitals.js" | addHash }}"{% endif %}>
+    <script async defer src="{{ 'js/min.js' | addHash }}"
+      {% if webvitals %}data-cwv-src="{{ 'js/web-vitals.js' | addHash }}"{% endif %}>
     </script>
     {% if googleanalytics %}
-      <script async defer src="{{ "/js/cached.js" | addHash }}"></script>
+      <script async defer src="{{ 'js/cached.js' | addHash }}"></script>
     {% endif %}
     <!-- Notably iOS UAs also contain Mac OS X -->
     <script csp-hash>if (/Mac OS X/.test(navigator.userAgent))document.documentElement.classList.add('apple')

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -44,7 +44,7 @@ templateClass: tmpl-post
     "name": "{{ metadata.publisher.name }}",
     "logo": {
       "@type": "ImageObject",
-      "url": "{{ '/img/favicon/favicon-192x192.png' | addHash }}"
+      "url": "{{ 'img/favicon/favicon-192x192.png' | addHash }}"
     }
   },
   "url": "{{ metadata.url }}{{ canonicalUrl or page.url }}",


### PR DESCRIPTION
## Summary
- normalize the addHash filter to read assets without a leading slash and emit URLs with the configured pathPrefix
- update script and icon references to use the revised helper so hashed assets resolve under /blog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d98c2d29248332ae2774bc2931c3b3