### PR TITLE
Fix homepage post links to respect path prefix

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -16,7 +16,12 @@ date: Last Modified
   <ul>
     {% for post in collections.post %}
       <li>
-        <a href="{{ post.url }}">{{ post.data.title }}</a> – {{ post.date | date("dd MMM yyyy") }}
+        {% set pathPrefix = '/' | url %}
+        {% set postHref = post.url %}
+        {% if pathPrefix != '/' and postHref.indexOf(pathPrefix) == 0 %}
+          {% set postHref = postHref | replace(pathPrefix, '/') %}
+        {% endif %}
+        <a href="{{ postHref | url }}">{{ post.data.title }}</a> – {{ post.date | date("dd MMM yyyy") }}
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
## Summary
- normalize each homepage post link before applying Eleventy’s `url` filter so the global pathPrefix is respected

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d98cd14fc08332bea0fb6a6dd191f9