### PR TITLE
Sort Eleventy post collection by date

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -188,7 +188,9 @@ module.exports = function (eleventyConfig) {
   });
 
   eleventyConfig.addCollection("post", function (collectionApi) {
-    return collectionApi.getFilteredByGlob("src/posts/**/*.md");
+    return collectionApi
+      .getFilteredByGlob("src/posts/**/*.md")
+      .sort((a, b) => b.date - a.date);
   });
   eleventyConfig.addCollection("posts", function (collectionApi) {
     return collectionApi.getFilteredByTag("posts");


### PR DESCRIPTION
## Summary
- sort the Eleventy `post` collection by descending publication date so templates receive newest posts first

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9913286e88332bc3802491e8a3409